### PR TITLE
Fix share link to use direct download URL

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -98,7 +98,7 @@ export default function Home() {
 
       const responseText = await uploadPromise;
       const result = JSON.parse(responseText);
-      const fullUrl = `${window.location.origin}/f/${result.hash}`;
+      const fullUrl = `${window.location.origin}/api/download/${result.hash}`;
       setUploadedUrl(fullUrl);
     } catch (error) {
       console.error("Upload error:", error);


### PR DESCRIPTION
Change frontend share URL from /f/${hash} to /api/download/${hash} to provide direct download links instead of HTML pages.

closes #3 