### PR TITLE
Fix API returning JSON instead of HTML errors

### DIFF
--- a/frontend/src/app/api/download/[hash]/route.ts
+++ b/frontend/src/app/api/download/[hash]/route.ts
@@ -23,6 +23,16 @@ export async function GET(
     );
 
     if (!response.ok) {
+      const contentType = response.headers.get('content-type');
+
+      if (contentType?.includes('text/html')) {
+        const html = await response.text();
+        return new NextResponse(html, {
+          status: response.status,
+          headers: { 'Content-Type': 'text/html' }
+        });
+      }
+
       const error = await response.text();
       return NextResponse.json(
         { error: error || "Download failed" },


### PR DESCRIPTION
When backend returns HTML error pages (403 IP restriction, 404 not found), pass them through directly instead of wrapping in JSON response.

closes #1 